### PR TITLE
Add Colab badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # python-awesome
 Learn Python, Easy to learn, Awesome
 
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/gautam1858/python-awesome]
+
 ![Python](https://user-images.githubusercontent.com/4949778/50740273-10ad1280-1212-11e9-8b84-0a82f5d02c2f.png)
 
 Welcome to python-awesome. These notebooks are part of my Machine Learning curriculum that I am teaching in an University as part of their Graduate Program. 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # python-awesome
 Learn Python, Easy to learn, Awesome
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/gautam1858/python-awesome]
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/gautam1858/python-awesome)
 
 ![Python](https://user-images.githubusercontent.com/4949778/50740273-10ad1280-1212-11e9-8b84-0a82f5d02c2f.png)
 


### PR DESCRIPTION
Fixes #4 

Users can directly open the repository notebooks on Colab just by clicking on the badge. It is beginner-friendly and intuitive.